### PR TITLE
feat: vendor notifications for user signups with dropdown and detail view

### DIFF
--- a/client/src/components/NotificationBell/NotificationBell.css
+++ b/client/src/components/NotificationBell/NotificationBell.css
@@ -1,0 +1,57 @@
+/* NotificationBell.css */
+
+.dropdown-content {
+  width: 300px;
+  max-height: 400px;
+  background-color: #fff;
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdown-content .notification-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.dropdown-content .notification-item {
+  padding-left: 8px;
+  padding-right: 8px;
+  background-color: white;
+  cursor: pointer;
+}
+
+.dropdown-content .load-more-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+
+.dropdown-content .notification-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.unread-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #1890ff;
+  margin-left: 8px;
+}
+
+.custom-badge .ant-badge-count {
+  min-width: 16px;
+  height: 16px;
+  font-size: 10px;
+  line-height: 16px;
+  padding: 0 5px;
+}
+
+.custom-badge .ant-scroll-number {
+  transition: all 0.5s ease;
+}

--- a/client/src/components/NotificationBell/NotificationBell.js
+++ b/client/src/components/NotificationBell/NotificationBell.js
@@ -1,0 +1,239 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Badge, Dropdown, List, Typography, Button } from "antd";
+import { BellOutlined } from "@ant-design/icons";
+import { useNavigate } from "react-router-dom";
+import getBaseURL from "../../utils/config";
+import dayjs from "dayjs";
+import toast from "react-hot-toast";
+import "./NotificationBell.css";
+
+// Format user ID to show last 6 characters — used in dropdown preview for clarity
+const formatUserId = (uuid) => (uuid ? `(...${uuid.slice(-6)})` : "");
+
+const NotificationBell = () => {
+  // Get base API URL and router navigation handler
+  const baseURL = getBaseURL();
+  const navigate = useNavigate();
+
+  // Ref
+  const previousTotalCountRef = useRef(0); // track previously known notification count for polling comparison
+
+  // State
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true); // whether more notifications exist beyond current page
+  const [unreadCount, setUnreadCount] = useState(0); // bell icon badge counter
+
+  // On mount: fetch initial notifications, then poll for new ones every 30s (compared by total count)
+  useEffect(() => {
+    let interval;
+
+    const initialize = async () => {
+      await fetchInitialNotifications();
+      interval = setInterval(pollForNewNotifications, 30000);
+    };
+
+    initialize();
+
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, []);
+
+  // Load latest notifications (first 10), unread count, and total count
+  const fetchInitialNotifications = async () => {
+    try {
+      const [notifRes, countRes, unreadRes] = await Promise.all([
+        fetch(`${baseURL}/notifications/initial`, {
+          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+        }),
+        fetch(`${baseURL}/notifications/count`, {
+          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+        }),
+        fetch(`${baseURL}/notifications/unread-count`, {
+          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+        }),
+      ]);
+
+      if (!notifRes.ok || !countRes.ok || !unreadRes.ok)
+        throw new Error("Failed to fetch notification data");
+
+      const notifData = await notifRes.json();
+      const { count } = await countRes.json();
+      const { unreadCount } = await unreadRes.json();
+
+      setNotifications(notifData.notifications);
+      setHasMore(notifData.notifications.length === 10); // enable "Load More" if we got a full page (10 notifications)
+      previousTotalCountRef.current = count;
+      setUnreadCount(unreadCount);
+    } catch (err) {
+      console.error("Error fetching initial notifications:", err);
+    }
+  };
+
+  // Re-fetch if total count increases, indicating new notifications
+  const pollForNewNotifications = async () => {
+    try {
+      const res = await fetch(`${baseURL}/notifications/count`, {
+        headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      });
+
+      if (!res.ok) throw new Error("Failed to fetch count");
+
+      const { count } = await res.json();
+
+      if (count > previousTotalCountRef.current) {
+        toast.success("You have new notifications!");
+        await fetchInitialNotifications();
+      }
+    } catch (err) {
+      console.error("Polling error:", err);
+    }
+  };
+
+  // Fetch next page of notifications and append
+  const fetchMore = async () => {
+    if (loading) return;
+    setLoading(true);
+
+    try {
+      const res = await fetch(
+        `${baseURL}/notifications/more?offset=${notifications.length}`,
+        {
+          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+        }
+      );
+      if (!res.ok) throw new Error("Failed to fetch more notifications");
+
+      const data = await res.json();
+      const newItems = data.notifications;
+
+      if (newItems.length === 0) {
+        setHasMore(false); // no more pages left
+        return;
+      }
+
+      setNotifications((prev) => [...prev, ...data.notifications]);
+    } catch (err) {
+      console.error("Error loading more notifications:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // When dropdown closes: mark visible unread notifications as read
+  const handleDropdownVisibleChange = async (visible) => {
+    if (!visible) {
+      const unreadVisibleIds = notifications
+        .filter((n) => !n.read)
+        .map((n) => n.id);
+
+      if (unreadVisibleIds.length > 0) {
+        await fetch(`${baseURL}/notifications/mark-read`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+          body: JSON.stringify({ ids: unreadVisibleIds }),
+        });
+
+        // Update local UI to reflect read state
+        setNotifications((prev) =>
+          prev.map((n) =>
+            unreadVisibleIds.includes(n.id) ? { ...n, read: true } : n
+          )
+        );
+        setUnreadCount((prev) => Math.max(prev - unreadVisibleIds.length, 0));
+      }
+    }
+  };
+
+  // Renders a single notification item or the "Load More" button
+  const renderNotificationItem = (item) => {
+    if (item.isLoadMoreButton) {
+      return (
+        <List.Item className="load-more-container">
+          <Button
+            disabled={loading}
+            loading={loading}
+            size="small"
+            onClick={fetchMore}
+          >
+            Load More
+          </Button>
+        </List.Item>
+      );
+    }
+
+    return (
+      <List.Item
+        className="notification-item"
+        onClick={() => navigate(`/notifications/${item.id}`)}
+      >
+        <List.Item.Meta
+          title={
+            <div className="notification-title">
+              <div style={{ fontWeight: item.read ? "normal" : "bold" }}>
+                {item.parentName}{" "}
+                <span style={{ color: "#999", fontWeight: "normal" }}>
+                  {formatUserId(item.parentUserId)}
+                </span>
+              </div>
+              {!item.read && <div className="unread-dot" />}
+            </div>
+          }
+          description={
+            <>
+              <Typography.Text>{item.listingTitle}</Typography.Text>
+              <br />
+              <small>
+                {dayjs(item.timestamp).format("MMM D, YYYY h:mm A")}
+              </small>
+            </>
+          }
+        />
+      </List.Item>
+    );
+  };
+
+  // Dropdown menu with notifications + optional Load More
+  const dropdownContent = (
+    <div className="dropdown-content">
+      <div className="notification-list">
+        <List
+          itemLayout="horizontal"
+          dataSource={
+            hasMore
+              ? [...notifications, { isLoadMoreButton: true }]
+              : notifications
+          }
+          locale={{ emptyText: "No notifications yet." }}
+          renderItem={renderNotificationItem}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <Dropdown
+      dropdownRender={() => dropdownContent}
+      trigger={["click"]}
+      placement="bottomRight"
+      arrow
+      onOpenChange={handleDropdownVisibleChange}
+    >
+      <Badge
+        count={unreadCount}
+        overflowCount={99}
+        size="small"
+        offset={[0, 3]}
+        className="custom-badge"
+      >
+        <BellOutlined style={{ fontSize: "16px", cursor: "pointer" }} />
+      </Badge>
+    </Dropdown>
+  );
+};
+
+export default NotificationBell;

--- a/client/src/components/NotificationBell/index.js
+++ b/client/src/components/NotificationBell/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NotificationBell";

--- a/client/src/components/NotificationDetail/NotificationDetail.js
+++ b/client/src/components/NotificationDetail/NotificationDetail.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import getBaseURL from "../../utils/config";
+import { Card, Typography, Spin } from "antd";
+import dayjs from "dayjs";
+
+const NotificationDetail = () => {
+  // Get base API URL and route parameter
+  const baseURL = getBaseURL();
+  const { id } = useParams();
+
+  // State
+  const [notification, setNotification] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // On mount: fetch notification detail by ID
+  useEffect(() => {
+    const fetchDetail = async () => {
+      try {
+        const res = await fetch(`${baseURL}/notifications/${id}`, {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        });
+
+        if (!res.ok) throw new Error("Failed to fetch notification");
+
+        const data = await res.json();
+        setNotification(data);
+      } catch (err) {
+        console.error("Error:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDetail();
+  }, [id, baseURL]);
+
+  // Loading state
+  if (loading) return <Spin />;
+
+  // If notification wasn't found (404 from API)
+  if (!notification)
+    return (
+      <Typography.Text type="danger">Notification not found.</Typography.Text>
+    );
+
+  // Render notification info
+  return (
+    <Card
+      title="Notification Details"
+      style={{ maxWidth: 600, margin: "auto" }}
+    >
+      <p>
+        <strong>Parent:</strong> {notification.parentName}
+      </p>
+      <p>
+        <strong>Listing Title:</strong> {notification.listingTitle}
+      </p>
+      <p>
+        <strong>Signed Up:</strong>{" "}
+        {dayjs(notification.timestamp).format("MMM D, YYYY h:mm A")}
+      </p>
+      <hr />
+      <p>
+        <strong>Child Name:</strong> {notification.childName}
+      </p>
+      <p>
+        <strong>Age:</strong> {notification.childAge}
+      </p>
+      <p>
+        <strong>Gender:</strong> {notification.childGender}
+      </p>
+    </Card>
+  );
+};
+
+export default NotificationDetail;

--- a/client/src/components/NotificationDetail/index.js
+++ b/client/src/components/NotificationDetail/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NotificationDetail";

--- a/client/src/layouts/PartnerHomeLayout.js
+++ b/client/src/layouts/PartnerHomeLayout.js
@@ -9,6 +9,7 @@ import { Layout, Menu, Image, Divider, Avatar } from "antd";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
 import UserContext from "../components/UserContext";
+import NotificationBell from "../components/NotificationBell";
 
 const { Header, Sider, Content } = Layout;
 
@@ -116,28 +117,28 @@ const PartnerHomeLayout = ({ setAuth }) => {
           <Menu
             mode="horizontal"
             style={{ flex: 1, minWidth: 0, display: "block" }}
-          >
-            <Menu.Item key="logout" style={{ float: "right" }}>
-              <LogoutOutlined
-                onClick={() => {
-                  localStorage.clear();
-                  setAuth(false);
-                  toast.success("Logout successfully");
-                  navigate("/login");
-                }}
-              />
-            </Menu.Item>
-            <Menu.Item
-              key="notification"
-              style={{ float: "right" }}
-              onClick={() => {
-                // TODO: Popover antd to show a list of notifcations
-              }}
-            >
-              {/* TODO: <Badge> */}
-              <i className="fa fa-bell-o"></i>
-            </Menu.Item>
-          </Menu>
+            items={[
+              {
+                key: "logout",
+                style: { float: "right" },
+                label: (
+                  <LogoutOutlined
+                    onClick={() => {
+                      localStorage.clear();
+                      setAuth(false);
+                      toast.success("Logout successfully");
+                      navigate("/login");
+                    }}
+                  />
+                ),
+              },
+              {
+                key: "notification",
+                style: { float: "right" },
+                label: <NotificationBell />,
+              },
+            ]}
+          />
         </Header>
         <Content
           style={{

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -15,6 +15,7 @@ import useAuth from "../hooks/useAuth";
 import Class from "../components/Classes/Class";
 import Profile from "../components/Profile";
 import { DataProvider } from "../hooks/DataContext";
+import NotificationDetail from "../components/NotificationDetail/NotificationDetail";
 
 const Routers = () => {
   const { isAuthenticated, loading, setLoading, user, setAuth } = useAuth();
@@ -75,6 +76,10 @@ const Routers = () => {
               />
               <Route path="class/:listing_id" element={<Class />} />
               <Route path="create-class" element={<CreateClass />} />
+              <Route
+                path="notifications/:id"
+                element={<NotificationDetail />}
+              />
             </Route>
           </Route>
         </Route>


### PR DESCRIPTION
## ✨ What does this PR do?
Implements vendor-facing signup notifications with a dropdown preview and detailed view.

## 🔨 Changes made
- Added bell icon in top bar with unread badge
- Dropdown shows recent notifications:
  - Parent name, listing title, signup timestamp
- Each notification links to a detailed page with:
  - Parent info and child demographics (name, age, gender)
- Added pagination with "Load More" button
- Marks notifications as read when dropdown closes
- Polls every 30s for new notifications; shows toast on update

## 🧪 How to test
1. Log in as a vendor with seeded notification data
2. Verify bell icon badge reflects unread count
3. Open dropdown, check content, timestamps, click behavior
5. Visit detail page,  confirm all data is shown
6. Test polling and read-state behavior
